### PR TITLE
Fix GitHub Pages deployment: use website/ directory as primary source

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -26,10 +26,22 @@ jobs:
         # Create a completely clean directory with only website files
         mkdir -p website-deploy
         
-        # Copy only essential website files
-        cp *.html website-deploy/ 2>/dev/null || true
+        # Copy website files from the website/ directory (primary source)
+        if [ -d "website" ]; then
+          cp -r website/* website-deploy/ 2>/dev/null || true
+          echo "Copied files from website/ directory"
+        fi
+        
+        # Copy essential files from root if they don't exist in website/
+        if [ ! -f "website-deploy/index.html" ]; then
+          cp index.html website-deploy/ 2>/dev/null || true
+        fi
+        if [ ! -f "website-deploy/README.md" ]; then
+          cp README.md website-deploy/ 2>/dev/null || true
+        fi
+        
+        # Copy .nojekyll file
         cp .nojekyll website-deploy/ 2>/dev/null || true
-        cp README.md website-deploy/ 2>/dev/null || true
         
         # Remove any problematic directories that might have been copied
         rm -rf website-deploy/data/


### PR DESCRIPTION
## 🚀 GitHub Pages Deployment Fix

### Issue Resolved
GitHub Pages build was failing with exit code 1 after processing HTML files. The deployment workflow was trying to copy files from the wrong location.

### Root Cause
- GitHub Pages workflow was copying HTML files from root directory
- Main website files are located in website/ directory, not root
- Duplicate HTML files in both locations caused deployment conflicts

### Solution Implemented
- Updated deployment workflow to use website/ directory as primary source
- Added fallback strategy for root files if needed
- Validated all HTML files for proper syntax

### Benefits
- Correct File Source: Uses actual website files from website/ directory
- Fallback Protection: Still includes root files if needed
- Clean Deployment: No more duplicate file conflicts
- Reliable Build: Proper file structure for GitHub Pages

### Impact
This fix ensures GitHub Pages deployment will work correctly and the website will be accessible at the expected URL.