### PR TITLE
Download and verify miniconda installer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,13 +173,14 @@ commands:
             fi
 
             # Verify SHA256 checksum to prevent supply chain attacks
-            # Use GitHub API to get the latest tag and verify against sha256sum.txt
+            # Use GitHub API to get the latest tag and verify against individual checksum file
             BASENAME=$(basename "$MINIFORGE_URL")
             # Avoid SIGPIPE from curl | grep by writing to a temp file
             curl -sSfL https://api.github.com/repos/conda-forge/miniforge/releases/latest -o latest_release.json
             TAG=$(sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' latest_release.json | head -n1)
             rm -f latest_release.json
-            CHECKSUM_URL="https://github.com/conda-forge/miniforge/releases/download/$TAG/sha256sum.txt"
+            # Use the individual checksum file for the specific installer
+            CHECKSUM_URL="https://github.com/conda-forge/miniforge/releases/download/$TAG/Miniforge3-$TAG-Linux-x86_64.sh.sha256"
             echo "Resolved installer: $BASENAME"
             echo "Checksum URL: $CHECKSUM_URL"
             if command -v curl >/dev/null 2>&1; then
@@ -190,9 +191,9 @@ commands:
               echo "Warning: neither curl nor wget available to fetch checksum; aborting for safety." >&2
               exit 1
             fi
-            # Compute actual checksum and compare to the line matching the installer filename
+            # Compute actual checksum and compare to the expected checksum
             ACTUAL_SUM=$(sha256sum miniconda.sh | awk '{print $1}')
-            EXPECTED_SUM=$(grep "  $BASENAME$" miniconda.sha256sum | awk '{print $1}')
+            EXPECTED_SUM=$(cat miniconda.sha256sum | awk '{print $1}')
             if [ -z "$EXPECTED_SUM" ]; then
               echo "Checksum file empty or unavailable. Aborting to be safe." >&2
               rm -f miniconda.sh miniconda.sha256sum

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,8 +156,10 @@ commands:
           name: Install and setup Miniconda (SIMPLIFIED)
           command: |
             set -euxo pipefail
-            # Download Miniforge (Conda-Forge) installer with stable checksum endpoint
-            MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh"
+            # Parameterize OS/ARCH for Miniforge installer
+            OS_NAME="Linux"
+            ARCH_NAME="x86_64"
+            MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-${OS_NAME}-${ARCH_NAME}.sh"
 
             if command -v wget >/dev/null 2>&1; then
               wget -O miniconda.sh "$MINIFORGE_URL"
@@ -180,7 +182,7 @@ commands:
             TAG=$(sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' latest_release.json | head -n1)
             rm -f latest_release.json
             # Use the individual checksum file for the specific installer
-            CHECKSUM_URL="https://github.com/conda-forge/miniforge/releases/download/$TAG/Miniforge3-$TAG-Linux-x86_64.sh.sha256"
+            CHECKSUM_URL="https://github.com/conda-forge/miniforge/releases/download/$TAG/Miniforge3-$TAG-${OS_NAME}-${ARCH_NAME}.sh.sha256"
             echo "Resolved installer: $BASENAME"
             echo "Checksum URL: $CHECKSUM_URL"
             if command -v curl >/dev/null 2>&1; then
@@ -193,7 +195,7 @@ commands:
             fi
             # Compute actual checksum and compare to the expected checksum
             ACTUAL_SUM=$(sha256sum miniconda.sh | awk '{print $1}')
-            EXPECTED_SUM=$(cat miniconda.sha256sum | awk '{print $1}')
+            EXPECTED_SUM=$(awk '{print $1}' < miniconda.sha256sum)
             if [ -z "$EXPECTED_SUM" ]; then
               echo "Checksum file empty or unavailable. Aborting to be safe." >&2
               rm -f miniconda.sh miniconda.sha256sum

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,13 +176,18 @@ commands:
 
             # Verify SHA256 checksum to prevent supply chain attacks
             # Use GitHub API to get the latest tag and verify against individual checksum file
-            BASENAME=$(basename "$MINIFORGE_URL")
+            INSTALLER_BASENAME=$(basename "$MINIFORGE_URL")
             # Avoid SIGPIPE from curl | grep by writing to a temp file
             curl -sSfL https://api.github.com/repos/conda-forge/miniforge/releases/latest -o latest_release.json
-            TAG=$(sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' latest_release.json | head -n1)
+            if command -v jq >/dev/null 2>&1; then
+              TAG=$(jq -r .tag_name latest_release.json)
+            else
+              TAG=$(sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"[:space:]]*\)".*/\1/p' latest_release.json | head -n1)
+            fi
             rm -f latest_release.json
-            # Use the individual checksum file for the specific installer
-            CHECKSUM_URL="https://github.com/conda-forge/miniforge/releases/download/$TAG/Miniforge3-$TAG-${OS_NAME}-${ARCH_NAME}.sh.sha256"
+            # Build checksum filename dynamically from installer basename (robust across variants/architectures)
+            CHECKSUM_FILENAME=$(echo "$INSTALLER_BASENAME" | sed -E "s/^([^-]+)-(.*)$/\1-$TAG-\2.sha256/")
+            CHECKSUM_URL="https://github.com/conda-forge/miniforge/releases/download/$TAG/$CHECKSUM_FILENAME"
             echo "Resolved installer: $BASENAME"
             echo "Checksum URL: $CHECKSUM_URL"
             if command -v curl >/dev/null 2>&1; then

--- a/install_miniforge_fixed.sh
+++ b/install_miniforge_fixed.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Fixed Miniforge Installation Script
+# This script demonstrates the corrected approach to downloading and verifying Miniforge
+
+set -euxo pipefail
+
+echo "🚀 Installing Miniforge with corrected checksum verification..."
+
+# Download Miniforge installer
+MINIFORGE_URL="https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh"
+
+if command -v wget >/dev/null 2>&1; then
+    wget -O miniconda.sh "$MINIFORGE_URL"
+elif command -v curl >/dev/null 2>&1; then
+    curl -L -o miniconda.sh "$MINIFORGE_URL"
+else
+    echo "Error: neither wget nor curl available to download Miniforge." >&2
+    exit 1
+fi
+
+# Get the installer basename and latest release info
+BASENAME=$(basename "$MINIFORGE_URL")
+curl -sSfL https://api.github.com/repos/conda-forge/miniforge/releases/latest -o latest_release.json
+TAG=$(sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' latest_release.json | head -n1)
+rm -f latest_release.json
+
+# FIXED: Use the individual checksum file for the specific installer
+CHECKSUM_URL="https://github.com/conda-forge/miniforge/releases/download/$TAG/Miniforge3-$TAG-Linux-x86_64.sh.sha256"
+
+echo "Resolved installer: $BASENAME"
+echo "Checksum URL: $CHECKSUM_URL"
+
+# Download the checksum file
+if command -v curl >/dev/null 2>&1; then
+    curl -sSfL "$CHECKSUM_URL" -o miniconda.sha256sum
+elif command -v wget >/dev/null 2>&1; then
+    wget -qO miniconda.sha256sum "$CHECKSUM_URL"
+else
+    echo "Warning: neither curl nor wget available to fetch checksum; aborting for safety." >&2
+    exit 1
+fi
+
+# Verify checksum
+ACTUAL_SUM=$(sha256sum miniconda.sh | awk '{print $1}')
+EXPECTED_SUM=$(cat miniconda.sha256sum | awk '{print $1}')
+
+echo "Actual checksum:   $ACTUAL_SUM"
+echo "Expected checksum: $EXPECTED_SUM"
+
+if [ -z "$EXPECTED_SUM" ]; then
+    echo "❌ Checksum file empty or unavailable. Aborting to be safe." >&2
+    rm -f miniconda.sh miniconda.sha256sum
+    exit 1
+fi
+
+if [ "$ACTUAL_SUM" != "$EXPECTED_SUM" ]; then
+    echo "❌ Checksum verification failed! Expected $EXPECTED_SUM, got $ACTUAL_SUM" >&2
+    rm -f miniconda.sh miniconda.sha256sum
+    exit 1
+fi
+
+echo "✅ Checksum verification successful!"
+rm -f miniconda.sha256sum
+
+# Install Miniforge
+chmod +x miniconda.sh
+bash miniconda.sh -b -p "$HOME/miniforge3"
+rm -f miniconda.sh
+
+echo "✅ Miniforge installation completed successfully!"
+echo "📍 Installed at: $HOME/miniforge3"
+echo "🔧 To use: export PATH=\"\$HOME/miniforge3/bin:\$PATH\""

--- a/install_miniforge_fixed.sh
+++ b/install_miniforge_fixed.sh
@@ -43,7 +43,7 @@ fi
 
 # Verify checksum
 ACTUAL_SUM=$(sha256sum miniconda.sh | awk '{print $1}')
-EXPECTED_SUM=$(cat miniconda.sha256sum | awk '{print $1}')
+EXPECTED_SUM=$(awk '{print $1}' < miniconda.sha256sum)
 
 echo "Actual checksum:   $ACTUAL_SUM"
 echo "Expected checksum: $EXPECTED_SUM"

--- a/scripts/deployment/install_miniforge.sh
+++ b/scripts/deployment/install_miniforge.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+# Robust Miniforge installer with checksum verification and cross-platform support
+# Usage: install_miniforge.sh [--prefix <install_dir>]
+
+set -euo pipefail
+
+PREFIX="${HOME}/miniconda"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prefix)
+      PREFIX="$2"; shift 2;;
+    *)
+      echo "Unknown argument: $1" >&2; exit 2;;
+  esac
+done
+
+workdir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$workdir" || true
+}
+trap cleanup EXIT INT TERM
+
+detect_os_arch() {
+  local uname_s uname_m os_name arch_name
+  uname_s="$(uname -s)"
+  uname_m="$(uname -m)"
+  case "$uname_s" in
+    Darwin) os_name="MacOSX" ;;
+    Linux)  os_name="Linux" ;;
+    *)      os_name="$uname_s" ;;
+  esac
+
+  case "$os_name" in
+    MacOSX)
+      case "$uname_m" in
+        arm64|aarch64) arch_name="arm64" ;;
+        x86_64)        arch_name="x86_64" ;;
+        *)             arch_name="x86_64" ;;
+      esac
+      ;;
+    Linux)
+      case "$uname_m" in
+        aarch64|arm64) arch_name="aarch64" ;;
+        x86_64)        arch_name="x86_64" ;;
+        *)             arch_name="x86_64" ;;
+      esac
+      ;;
+    *)
+      arch_name="x86_64"
+      ;;
+  esac
+
+  echo "$os_name" "$arch_name"
+}
+
+main() {
+  read -r OS_NAME ARCH_NAME < <(detect_os_arch)
+
+  local BASENAME="Miniforge3-${OS_NAME}-${ARCH_NAME}.sh"
+  local LATEST_URL="https://github.com/conda-forge/miniforge/releases/latest/download/${BASENAME}"
+
+  echo "Resolved installer: ${BASENAME}"
+
+  # Fetch latest tag for checksum URL
+  curl -sSfL https://api.github.com/repos/conda-forge/miniforge/releases/latest -o "${workdir}/latest_release.json"
+  local TAG
+  TAG=$(sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${workdir}/latest_release.json" | head -n1)
+  if [[ -z "${TAG}" ]]; then
+    echo "Failed to resolve latest tag from GitHub API" >&2
+    exit 1
+  fi
+
+  local CHECKSUM_URL="https://github.com/conda-forge/miniforge/releases/download/${TAG}/Miniforge3-${TAG}-${OS_NAME}-${ARCH_NAME}.sh.sha256"
+  echo "Checksum URL: ${CHECKSUM_URL}"
+
+  # Download installer and checksum
+  if command -v curl >/dev/null 2>&1; then
+    curl -sSfL "$LATEST_URL" -o "${workdir}/miniforge.sh"
+    curl -sSfL "$CHECKSUM_URL" -o "${workdir}/miniforge.sha256"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "${workdir}/miniforge.sh" "$LATEST_URL"
+    wget -qO "${workdir}/miniforge.sha256" "$CHECKSUM_URL"
+  else
+    echo "Error: neither curl nor wget available to download Miniforge." >&2
+    exit 1
+  fi
+
+  # Verify checksum
+  local ACTUAL EXPECTED
+  ACTUAL=$(sha256sum "${workdir}/miniforge.sh" | awk '{print $1}')
+  EXPECTED=$(awk '{print $1}' < "${workdir}/miniforge.sha256")
+
+  echo "Actual checksum:   ${ACTUAL}"
+  echo "Expected checksum: ${EXPECTED}"
+
+  if [[ -z "${EXPECTED}" ]] || [[ "${ACTUAL}" != "${EXPECTED}" ]]; then
+    echo "Checksum verification failed or missing. Aborting." >&2
+    exit 1
+  fi
+
+  # Install Miniforge
+  chmod +x "${workdir}/miniforge.sh"
+  bash "${workdir}/miniforge.sh" -b -p "${PREFIX}"
+  echo "Installed Miniforge at: ${PREFIX}"
+}
+
+main "$@"
+


### PR DESCRIPTION
Update Miniforge installer checksum verification in CircleCI config to use the correct per-installer SHA256 file, resolving a 404 error.

The previous logic attempted to download a generic `sha256sum.txt` file which does not exist for Miniforge releases. This PR modifies the `CHECKSUM_URL` to point to the specific installer's checksum file (e.g., `Miniforge3-$TAG-Linux-x86_64.sh.sha256`) and adjusts the parsing accordingly.

---
<a href="https://cursor.com/background-agent?bcId=bc-9dca6b76-5a9c-416e-8bfb-8f9df9d4b41e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9dca6b76-5a9c-416e-8bfb-8f9df9d4b41e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Fix Miniforge installer checksum validation by pointing CircleCI at the per-installer SHA256 file and include a standalone script to download, verify, and install Miniforge3.

Enhancements:
- Adjust checksum parsing to extract the expected hash directly from the individual checksum file.
- Add install_miniforge_fixed.sh script demonstrating the corrected download, verification, and installation process for Miniforge3.

CI:
- Update CircleCI config to fetch and parse the specific Miniforge3-<tag>-Linux-x86_64.sh.sha256 checksum file instead of a non-existent generic sha256sum.txt.