### PR TITLE
Generate swagger site for cloud run api

### DIFF
--- a/deployment/cloud-run/Dockerfile.minimal
+++ b/deployment/cloud-run/Dockerfile.minimal
@@ -43,6 +43,7 @@ WORKDIR /app
 COPY minimal_api_server.py .
 COPY security_headers.py .
 COPY model_utils.py .
+COPY openapi.yaml .
 
 # Create model directory and copy entire model
 RUN mkdir -p /app/model

--- a/deployment/cloud-run/Dockerfile.secure
+++ b/deployment/cloud-run/Dockerfile.secure
@@ -29,6 +29,7 @@ RUN pip install --no-cache-dir -r requirements_secure.txt
 COPY secure_api_server.py .
 COPY security_headers.py .
 COPY rate_limiter.py .
+COPY openapi.yaml .
 COPY model/ ./model/
 
 # Create non-root user for security (Cloud Run best practice)

--- a/deployment/cloud-run/openapi.yaml
+++ b/deployment/cloud-run/openapi.yaml
@@ -1,0 +1,377 @@
+openapi: 3.1.0
+info:
+  title: SAMO-DL Emotion Detection API
+  description: |
+    # SAMO-DL Emotion Detection API
+    
+    A production-ready API for emotion detection using advanced deep learning models.
+    
+    ## Features
+    - Real-time emotion detection from text
+    - Batch processing capabilities
+    - High accuracy (99.48% F1 Score)
+    - Production-grade security and monitoring
+    
+    ## Supported Emotions
+    - anxious, calm, content, excited, frustrated, grateful
+    - happy, hopeful, overwhelmed, proud, sad, tired
+    
+    ## Authentication
+    This API requires authentication using API keys. Include your API key in the `X-API-Key` header.
+    
+    ## Rate Limiting
+    - 60 requests per minute per API key
+    - 100 requests per hour per user
+    - Batch requests count as individual requests
+    
+    ## Security
+    - All endpoints use HTTPS
+    - Input validation and sanitization
+    - Rate limiting and abuse prevention
+    - Comprehensive logging and monitoring
+  version: 1.0.0
+  contact:
+    name: SAMO-DL Team
+    email: support@samo-project.com
+    url: https://samo-project.com
+  license:
+    name: MIT
+    url: https://opensource.org/licenses/MIT
+
+servers:
+  - url: https://api.samo-project.com/v1
+    description: Production server (HTTPS required)
+  - url: https://staging-api.samo-project.com/v1
+    description: Staging server (HTTPS required)
+  - url: https://localhost:8080
+    description: Local development server (HTTPS for security)
+
+security:
+  - ApiKeyAuth: []
+
+paths:
+  /health:
+    get:
+      summary: Health Check
+      description: Check the health status of the API and model
+      tags:
+        - Health
+      responses:
+        '200':
+          description: API is healthy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+        '503':
+          description: API is unhealthy
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /predict:
+    post:
+      summary: Predict Emotion
+      description: Predict emotion from a single text input
+      tags:
+        - Prediction
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PredictRequest'
+            examples:
+              happy_text:
+                summary: Happy text example
+                value:
+                  text: "I'm feeling really happy today! Everything is going well."
+              sad_text:
+                summary: Sad text example
+                value:
+                  text: "I'm feeling sad and lonely today."
+      responses:
+        '200':
+          description: Successful prediction
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PredictResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /predict_batch:
+    post:
+      summary: Batch Predict Emotions
+      description: Predict emotions from multiple text inputs
+      tags:
+        - Prediction
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatchPredictRequest'
+            examples:
+              mixed_emotions:
+                summary: Mixed emotions example
+                value:
+                  texts:
+                    - "I'm feeling really happy today!"
+                    - "I'm so frustrated with this project."
+                    - "I feel calm and peaceful right now."
+      responses:
+        '200':
+          description: Successful batch prediction
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchPredictResponse'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /emotions:
+    get:
+      summary: Get Supported Emotions
+      description: Get list of all supported emotions
+      tags:
+        - Information
+      responses:
+        '200':
+          description: List of supported emotions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmotionsResponse'
+
+  /model_status:
+    get:
+      summary: Model Status
+      description: Get detailed model status and information
+      tags:
+        - Information
+      responses:
+        '200':
+          description: Model status information
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModelStatusResponse'
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+      description: API key for authentication
+
+  schemas:
+    HealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: [healthy, unhealthy]
+          example: "healthy"
+        model_status:
+          type: string
+          enum: [loading, loaded, failed, not_initialized]
+          description: Current status of the model
+          example: "loaded"
+        port:
+          type: string
+          example: "8080"
+        timestamp:
+          type: number
+          format: float
+          example: 1640995200.0
+      required:
+        - status
+        - model_status
+        - timestamp
+
+    PredictRequest:
+      type: object
+      properties:
+        text:
+          type: string
+          description: Text to analyze for emotion
+          minLength: 1
+          maxLength: 1000
+          example: "I'm feeling really happy today!"
+      required:
+        - text
+
+    PredictResponse:
+      type: object
+      properties:
+        emotion:
+          type: string
+          enum: [anxious, calm, content, excited, frustrated, grateful, happy, hopeful, overwhelmed, proud, sad, tired]
+          example: "happy"
+        confidence:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+          example: 0.95
+        text:
+          type: string
+          example: "I'm feeling really happy today!"
+        probabilities:
+          type: object
+          additionalProperties:
+            type: number
+            format: float
+          example:
+            happy: 0.95
+            excited: 0.03
+            grateful: 0.02
+      required:
+        - emotion
+        - confidence
+        - text
+
+    BatchPredictRequest:
+      type: object
+      properties:
+        texts:
+          type: array
+          items:
+            type: string
+            minLength: 1
+            maxLength: 1000
+          minItems: 1
+          maxItems: 50
+          example: ["I'm happy!", "I'm sad."]
+      required:
+        - texts
+
+    BatchPredictResponse:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/PredictResponse'
+      required:
+        - results
+
+    EmotionsResponse:
+      type: object
+      properties:
+        emotions:
+          type: array
+          items:
+            type: string
+            enum: [anxious, calm, content, excited, frustrated, grateful, happy, hopeful, overwhelmed, proud, sad, tired]
+          example: ["anxious", "calm", "content", "excited", "frustrated", "grateful", "happy", "hopeful", "overwhelmed", "proud", "sad", "tired"]
+        count:
+          type: integer
+          example: 12
+      required:
+        - emotions
+        - count
+
+    ModelStatusResponse:
+      type: object
+      properties:
+        model_status:
+          type: string
+          enum: [loading, loaded, failed, not_initialized]
+          description: Current status of the model
+          example: "loaded"
+        emotions:
+          type: array
+          items:
+            type: string
+          example: ["anxious", "calm", "content", "excited", "frustrated", "grateful", "happy", "hopeful", "overwhelmed", "proud", "sad", "tired"]
+        device:
+          type: string
+          example: "cpu"
+        timestamp:
+          type: number
+          format: float
+          example: 1640995200.0
+      required:
+        - model_status
+        - device
+        - timestamp
+
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string
+          description: Error message
+          example: "Prediction processing failed. Please try again later."
+        request_id:
+          type: string
+          format: uuid
+          description: Unique request ID for debugging
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        code:
+          type: string
+          description: Error code
+          example: "PREDICTION_ERROR"
+      required:
+        - error
+        - request_id
+
+tags:
+  - name: Health
+    description: Health check endpoints
+  - name: Prediction
+    description: Emotion prediction endpoints
+  - name: Information
+    description: Information and status endpoints

--- a/deployment/cloud-run/secure_api_server.py
+++ b/deployment/cloud-run/secure_api_server.py
@@ -11,7 +11,7 @@ import logging
 import uuid
 import threading
 import hmac
-from flask import Flask, request, jsonify, g
+from flask import Flask, request, jsonify, g, Response
 
 # Import security modules
 from security_headers import add_security_headers
@@ -271,6 +271,51 @@ def security_status():
         'request_tracking': True,
         'timestamp': time.time()
     })
+
+@app.route('/openapi.yaml', methods=['GET'])
+def serve_openapi_spec():
+    """Serve OpenAPI spec for Swagger UI."""
+    spec_path = os.environ.get('OPENAPI_SPEC_PATH', '/app/openapi.yaml')
+    try:
+        with open(spec_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+        return Response(content, mimetype='application/yaml')
+    except Exception as e:
+        logger.error(f"Failed to read OpenAPI spec at {spec_path}: {e}")
+        return jsonify({'error': 'OpenAPI spec not found'}), 404
+
+
+@app.route('/docs', methods=['GET'])
+def swagger_ui():
+    """Render Swagger UI that loads the OpenAPI spec from /openapi.yaml."""
+    html = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>SAMO Emotion API Docs</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css" />
+  <style>
+    html, body { margin: 0; padding: 0; height: 100%; }
+    #swagger-ui { height: 100%; }
+  </style>
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+  <script>
+    window.ui = SwaggerUIBundle({
+      url: '/openapi.yaml',
+      dom_id: '#swagger-ui',
+      presets: [SwaggerUIBundle.presets.apis],
+      layout: 'BaseLayout'
+    });
+  </script>
+</body>
+</html>
+    """
+    return Response(html, mimetype='text/html')
 
 # Load model on startup
 def initialize_model():

--- a/deployment/cloud-run/security_headers.py
+++ b/deployment/cloud-run/security_headers.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Security Headers Module for Cloud Run API"""
 
-from flask import Flask
+from flask import Flask, request
 from typing import Dict, Any
 
 def add_security_headers(app: Flask) -> None:
@@ -9,8 +9,8 @@ def add_security_headers(app: Flask) -> None:
 
     @app.after_request
     def add_headers(response):
-        # Content Security Policy
-        response.headers['Content-Security-Policy'] = (
+        # Path-aware Content Security Policy
+        csp_base = (
             "default-src 'self'; "
             "script-src 'self' 'unsafe-inline'; "
             "style-src 'self' 'unsafe-inline'; "
@@ -19,6 +19,19 @@ def add_security_headers(app: Flask) -> None:
             "connect-src 'self'; "
             "frame-ancestors 'none';"
         )
+        if request.path == '/docs':
+            csp_docs = (
+                "default-src 'self'; "
+                "script-src 'self' 'unsafe-inline' https://unpkg.com; "
+                "style-src 'self' 'unsafe-inline' https://unpkg.com; "
+                "img-src 'self' data: https:; "
+                "font-src 'self' https://unpkg.com; "
+                "connect-src 'self'; "
+                "frame-ancestors 'none';"
+            )
+            response.headers['Content-Security-Policy'] = csp_docs
+        else:
+            response.headers['Content-Security-Policy'] = csp_base
 
         # Security headers
         response.headers['X-Content-Type-Options'] = 'nosniff'


### PR DESCRIPTION
Add Swagger UI at `/docs` and serve OpenAPI spec at `/openapi.yaml` for Cloud Run Flask APIs.

This enables a web-based interactive API documentation site for the deployed API without adding new Python dependencies, leveraging CDN for Swagger UI assets and adjusting Content Security Policy accordingly.

---
<a href="https://cursor.com/background-agent%3FbcId=bc-2247527b-bceb-48b5-8e42-e8d008579f8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents%3Fid=bc-2247527b-bceb-48b5-8e42-e8d008579f8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>