### PR TITLE
Enable docker scout for repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg=7:5.1.6-0+deb12u1 \
     gcc=4:12.2.0-3 \
     g++=4:12.2.0-3 \
+    build-essential \
+    python3-dev \
+    pkg-config \
+    git \
+    cmake \
     curl=7.88.1-10+deb12u12 \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Add build tools to Dockerfile to enable successful installation of `psutil` and `sentencepiece`.

---
<a href="https://cursor.com/background-agent?bcId=bc-387c48b9-1711-4d44-af8d-0aedff82c370">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-387c48b9-1711-4d44-af8d-0aedff82c370">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

