### PR TITLE
notebooks: add README to enable notebooks-only PR

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,13 @@
+# Notebooks
+
+This folder contains Jupyter notebooks for model training, experiments, and demos.
+
+- training/: End-to-end training workflows (GPU-friendly)
+- experiments/: Exploratory work and prototypes
+- demos/: Minimal examples
+- legacy/: Older reference notebooks
+
+Contribution guidelines:
+- Keep notebooks focused and small; prefer modular reusable code in `src/`.
+- Avoid committing large outputs; prefer text logs and save models/artifacts outside the repo.
+- Ensure any new dependencies are added to the appropriate requirements files and verified for security.


### PR DESCRIPTION
## Summary by Sourcery

Add a README to the notebooks directory to outline its structure and contribution guidelines.

Documentation:
- Introduce a notebooks/README.md detailing the purpose of subfolders for training, experiments, demos, and legacy notebooks.
- Include contribution guidelines to keep notebooks focused, manage outputs externally, and update dependencies with security checks.