### PR TITLE
Fix python 3.8 compatibility issues

### DIFF
--- a/src/api_rate_limiter.py
+++ b/src/api_rate_limiter.py
@@ -373,7 +373,7 @@ class TokenBucketRateLimiter:
         self,
         client_ip: str,
         user_agent: str = "",
-    ) -> tuple[bool, str, dict]:
+    ) -> Tuple[bool, str, dict]:
         """
         Check if request should be allowed.
 

--- a/src/data/embeddings.py
+++ b/src/data/embeddings.py
@@ -9,6 +9,7 @@ from sklearn.feature_extraction.text import TfidfVectorizer
 import logging
 import numpy as np
 import pandas as pd
+from typing import List, Optional
 
 
 
@@ -25,7 +26,7 @@ class BaseEmbedder:
     def __init__(self) -> None:
         self.model = None
 
-    def fit(self, texts: list[str]) -> "BaseEmbedder":
+    def fit(self, texts: List[str]) -> "BaseEmbedder":
         """Fit the embedding model on a list of texts.
 
         Args:
@@ -38,7 +39,7 @@ class BaseEmbedder:
         msg = "Subclasses must implement fit()"
         raise NotImplementedError(msg)
 
-    def transform(self, texts: list[str]) -> np.ndarray:
+    def transform(self, texts: List[str]) -> np.ndarray:
         """Transform texts into embeddings.
 
         Args:
@@ -51,7 +52,7 @@ class BaseEmbedder:
         msg = "Subclasses must implement transform()"
         raise NotImplementedError(msg)
 
-    def fit_transform(self, texts: list[str]) -> np.ndarray:
+    def fit_transform(self, texts: List[str]) -> np.ndarray:
         """Fit the model and transform texts into embeddings.
 
         Args:
@@ -69,7 +70,7 @@ class TfidfEmbedder(BaseEmbedder):
 
     def __init__(
         self,
-        max_features: int | None = 1000,
+        max_features: Optional[int] = 1000,
         min_df: int = 5,
         max_df: float = 0.8,
         ngram_range: tuple = (1, 2),
@@ -95,7 +96,7 @@ class TfidfEmbedder(BaseEmbedder):
             ngram_range=ngram_range,
         )
 
-    def fit(self, texts: list[str]) -> "TfidfEmbedder":
+    def fit(self, texts: List[str]) -> "TfidfEmbedder":
         """Fit the TF-IDF vectorizer on a list of texts.
 
         Args:
@@ -115,7 +116,7 @@ class TfidfEmbedder(BaseEmbedder):
         )
         return self
 
-    def transform(self, texts: list[str]) -> np.ndarray:
+    def transform(self, texts: List[str]) -> np.ndarray:
         """Transform texts into TF-IDF embeddings.
 
         Args:
@@ -164,7 +165,7 @@ class Word2VecEmbedder(BaseEmbedder):
         self.epochs = epochs
         self.model = None
 
-    def _preprocess_texts(self, texts: list[str]) -> list[list[str]]:
+    def _preprocess_texts(self, texts: List[str]) -> List[List[str]]:
         """Preprocess texts for Word2Vec training.
 
         Args:
@@ -176,7 +177,7 @@ class Word2VecEmbedder(BaseEmbedder):
         """
         return [simple_preprocess(text) for text in texts]
 
-    def fit(self, texts: list[str]) -> "Word2VecEmbedder":
+    def fit(self, texts: List[str]) -> "Word2VecEmbedder":
         """Fit Word2Vec model on a list of texts.
 
         Args:
@@ -207,7 +208,7 @@ class Word2VecEmbedder(BaseEmbedder):
         )
         return self
 
-    def transform(self, texts: list[str]) -> np.ndarray:
+    def transform(self, texts: List[str]) -> np.ndarray:
         """Transform texts into Word2Vec embeddings by averaging word vectors.
 
         Args:
@@ -237,7 +238,7 @@ class Word2VecEmbedder(BaseEmbedder):
 class FastTextEmbedder(Word2VecEmbedder):
     """FastText based text embedder."""
 
-    def fit(self, texts: list[str]) -> "FastTextEmbedder":
+    def fit(self, texts: List[str]) -> "FastTextEmbedder":
         """Fit FastText model on a list of texts.
 
         Args:

--- a/src/data/pipeline.py
+++ b/src/data/pipeline.py
@@ -28,9 +28,9 @@ class DataPipeline:
 
     def __init__(
         self,
-        preprocessor: JournalEntryPreprocessor | None = None,
-        validator: DataValidator | None = None,
-        feature_engineer: FeatureEngineer | None = None,
+        preprocessor: Optional[JournalEntryPreprocessor] = None,
+        validator: Optional[DataValidator] = None,
+        feature_engineer: Optional[FeatureEngineer] = None,
         embedding_method: str = "tfid",
     ) -> None:
         """Initialize data pipeline.
@@ -61,11 +61,11 @@ class DataPipeline:
 
     def run(
         self,
-        data_source: str | pd.DataFrame,
+        data_source: Union[str, pd.DataFrame],
         source_type: str = "db",
-        output_dir: str | None = None,
-        user_id: int | None = None,
-        limit: int | None = None,
+        output_dir: Optional[str] = None,
+        user_id: Optional[int] = None,
+        limit: Optional[int] = None,
         extract_topics: bool = True,
         save_intermediates: bool = False,
     ) -> Dict[str, pd.DataFrame]:
@@ -147,10 +147,10 @@ class DataPipeline:
 
     def _load_data(
         self,
-        data_source: str | pd.DataFrame,
+        data_source: Union[str, pd.DataFrame],
         source_type: str,
-        user_id: int | None,
-        limit: int | None,
+        user_id: Optional[int],
+        limit: Optional[int],
     ) -> pd.DataFrame:
         """Load data from specified source.
 
@@ -198,7 +198,7 @@ class DataPipeline:
         processed_df: pd.DataFrame,
         featured_df: pd.DataFrame,
         embeddings_df: pd.DataFrame,
-        topics_df: pd.DataFrame | None = None,
+        topics_df: Optional[pd.DataFrame] = None,
         save_intermediates: bool = False,
     ) -> None:
         """Save pipeline results to output directory.

--- a/src/data/preprocessing.py
+++ b/src/data/preprocessing.py
@@ -6,7 +6,7 @@ This module provides comprehensive text preprocessing functionality
 for journal entries and other text data.
 """
 import string
-from typing import List
+from typing import List, Optional
 
 import nltk
 import numpy as np
@@ -141,7 +141,7 @@ class TextPreprocessor:
 class JournalEntryPreprocessor:
     """Preprocessing pipeline for journal entries."""
 
-    def __init__(self, text_preprocessor: TextPreprocessor | None = None) -> None:
+    def __init__(self, text_preprocessor: Optional[TextPreprocessor] = None) -> None:
         """Initialize journal entry preprocessor.
 
         Args:

--- a/src/data/prisma_client.py
+++ b/src/data/prisma_client.py
@@ -4,7 +4,7 @@
         # Create a temporary JS file
         # Ensure we return a list, even if the result is a single dict
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Dict, List
 import json
 import subprocess
 
@@ -164,7 +164,7 @@ main();
             limit (int): Maximum number of entries to return
 
         Returns:
-            list[dict[str, Any]]: List of journal entries
+            List[Dict[str, Any]]: List of journal entries
 
         """
         script = """

--- a/src/models/emotion_detection/api_demo.py
+++ b/src/models/emotion_detection/api_demo.py
@@ -8,7 +8,7 @@ models and provides a preview of the API interface for Web Dev integration.
 import logging
 import time
 import traceback
-from typing import Optional
+from typing import Optional, List
 
 import torch
 import uvicorn
@@ -95,13 +95,13 @@ class EmotionResponse(BaseModel):
     confidence: float = Field(
         ..., description="Confidence score for primary emotion", ge=0.0, le=1.0, example=0.85
     )
-    predicted_emotions: list[str] = Field(
+    predicted_emotions: List[str] = Field(
         ..., description="Emotions above threshold", example=["joy", "gratitude", "optimism"]
     )
-    emotion_scores: list[float] = Field(
+    emotion_scores: List[float] = Field(
         ..., description="Scores for predicted emotions", example=[0.85, 0.72, 0.64]
     )
-    all_probabilities: list[float] = Field(
+    all_probabilities: List[float] = Field(
         ..., description="Probabilities for all emotions", example=[0.85, 0.72, 0.64, 0.0, 0.0]
     )
     processing_time_ms: float = Field(
@@ -323,7 +323,7 @@ async def analyze_emotion(
     description="Analyze emotions in multiple texts in a single request",
 )
 async def analyze_emotions_batch(
-    texts: list[str],
+    texts: List[str],
     threshold: float = 0.5,
     x_api_key: Optional[str] = Header(None, description="API key for authentication"),
 ):

--- a/src/models/emotion_detection/training_pipeline.py
+++ b/src/models/emotion_detection/training_pipeline.py
@@ -49,7 +49,7 @@ class EmotionDetectionTrainer:
         warmup_steps: int = 500,
         weight_decay: float = 0.01,
         freeze_initial_layers: int = 6,
-        unfreeze_schedule: Optional[list[int]] = None,
+        unfreeze_schedule: Optional[List[int]] = None,
         save_best_only: bool = True,
         early_stopping_patience: int = 3,
         evaluation_strategy: str = "epoch",

--- a/src/models/summarization/api_demo.py
+++ b/src/models/summarization/api_demo.py
@@ -15,7 +15,7 @@ Key Features:
 import logging
 import time
 from contextlib import asynccontextmanager
-from typing import Optional
+from typing import Optional, List
 
 import uvicorn
 from fastapi import BackgroundTasks, FastAPI, HTTPException
@@ -91,7 +91,7 @@ class SummarizeRequest(BaseModel):
 class BatchSummarizationRequest(BaseModel):
     """Request model for batch summarization."""
 
-    texts: list[str] = Field(..., description="List of texts to summarize")
+    texts: List[str] = Field(..., description="List of texts to summarize")
     max_length: Optional[int] = Field(128, ge=30, le=256)
     min_length: Optional[int] = Field(30, ge=10, le=100)
     focus_emotional: Optional[bool] = Field(True)
@@ -120,7 +120,7 @@ class SummarizationResponse(BaseModel):
 class BatchSummarizationResponse(BaseModel):
     """Response model for batch summarization."""
 
-    summaries: list[SummarizationResponse] = Field(..., description="List of summarization results")
+    summaries: List[SummarizationResponse] = Field(..., description="List of summarization results")
     total_processing_time_ms: float = Field(..., description="Total batch processing time")
     average_processing_time_ms: float = Field(..., description="Average per-item processing time")
 

--- a/src/models/voice_processing/api_demo.py
+++ b/src/models/voice_processing/api_demo.py
@@ -37,7 +37,7 @@ from fastapi import BackgroundTasks, FastAPI, File, Form, HTTPException, UploadF
 from fastapi.responses import JSONResponse
 from pathlib import Path
 from pydantic import BaseModel, Field
-from typing import Any
+from typing import Any, Optional, List, Dict
 import logging
 import os
 import tempfile
@@ -50,7 +50,7 @@ import uvicorn
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-whisper_transcriber: WhisperTranscriber | None = None
+whisper_transcriber: Optional[WhisperTranscriber] = None
 
 
 @asynccontextmanager
@@ -113,7 +113,7 @@ class TranscriptionResponse(BaseModel):
 class BatchTranscriptionResponse(BaseModel):
     """Response model for batch transcription."""
 
-    transcriptions: list[TranscriptionResponse] = Field(
+    transcriptions: List[TranscriptionResponse] = Field(
         ..., description="List of transcription results"
     )
     total_processing_time: float = Field(..., description="Total batch processing time")
@@ -127,7 +127,7 @@ class ErrorResponse(BaseModel):
 
     error: str = Field(..., description="Error type")
     message: str = Field(..., description="Error message")
-    details: dict | None = Field(None, description="Additional error details")
+    details: Optional[Dict] = Field(None, description="Additional error details")
 
 
 @app.get("/health")
@@ -150,8 +150,8 @@ async def health_check():
 @app.post("/transcribe", response_model=TranscriptionResponse)
 async def transcribe_audio(
     audio_file: UploadFile = File(...),
-    language: str | None = Form(None),
-    initial_prompt: str | None = Form(None),
+    language: Optional[str] = Form(None),
+    initial_prompt: Optional[str] = Form(None),
 ):
     """Transcribe a single audio file to text.
 
@@ -225,9 +225,9 @@ async def transcribe_audio(
 
 @app.post("/transcribe/batch", response_model=BatchTranscriptionResponse)
 async def transcribe_batch(
-    audio_files: list[UploadFile] = File(...),
-    language: str | None = Form(None),
-    initial_prompt: str | None = Form(None),
+    audio_files: List[UploadFile] = File(...),
+    language: Optional[str] = Form(None),
+    initial_prompt: Optional[str] = Form(None),
 ):
     """Transcribe multiple audio files in batch for efficiency.
 

--- a/src/security/jwt_manager.py
+++ b/src/security/jwt_manager.py
@@ -13,7 +13,7 @@ import logging
 import os
 import time
 from datetime import datetime, timedelta
-from typing import List, Optional, Union, Any
+from typing import List, Optional, Union, Any, Dict
 
 import jwt
 from pydantic import BaseModel, Field
@@ -54,7 +54,7 @@ class JWTManager:
         self.algorithm = algorithm
         self.blacklisted_tokens: dict = {}  # Changed to dict: {token: exp_datetime}
 
-    def create_access_token(self, user_data: dict[str, Any]) -> str:
+    def create_access_token(self, user_data: Dict[str, Any]) -> str:
         """Create a new access token"""
         payload = {
             "user_id": user_data["user_id"],
@@ -66,7 +66,7 @@ class JWTManager:
         }
         return jwt.encode(payload, self.secret_key, algorithm=self.algorithm)
 
-    def create_refresh_token(self, user_data: dict[str, Any]) -> str:
+    def create_refresh_token(self, user_data: Dict[str, Any]) -> str:
         """Create a new refresh token"""
         payload = {
             "user_id": user_data["user_id"],
@@ -79,7 +79,7 @@ class JWTManager:
         }
         return jwt.encode(payload, self.secret_key, algorithm=self.algorithm)
 
-    def create_token_pair(self, user_data: dict[str, Any]) -> TokenResponse:
+    def create_token_pair(self, user_data: Dict[str, Any]) -> TokenResponse:
         """Create both access and refresh tokens and return as a TokenResponse model."""
         access_token = self.create_access_token(user_data)
         refresh_token = self.create_refresh_token(user_data)

--- a/src/unified_ai_api.py
+++ b/src/unified_ai_api.py
@@ -205,8 +205,8 @@ class WebSocketConnectionManager:
     """Enhanced WebSocket connection manager with pooling and heartbeat."""
 
     def __init__(self):
-        self.active_connections: dict[str, set[WebSocket]] = defaultdict(set)
-        self.connection_metadata: dict[WebSocket, dict[str, Any]] = {}
+        self.active_connections: Dict[str, Set[WebSocket]] = defaultdict(set)
+        self.connection_metadata: Dict[WebSocket, Dict[str, Any]] = {}
         self.heartbeat_interval = 30  # seconds
         self.max_connections_per_user = 5
         self.connection_timeout = 300  # 5 minutes
@@ -253,7 +253,7 @@ class WebSocketConnectionManager:
         logger.info("WebSocket disconnected for user %s", user_id)
 
     async def send_personal_message(
-        self, message: dict[str, Any], websocket: WebSocket
+        self, message: Dict[str, Any], websocket: WebSocket
     ):
         """Send message to specific WebSocket with error handling."""
         try:
@@ -264,7 +264,7 @@ class WebSocketConnectionManager:
             logger.error("Failed to send message to WebSocket: %s", e)
             await self.disconnect(websocket)
 
-    async def broadcast_to_user(self, message: dict[str, Any], user_id: str):
+    async def broadcast_to_user(self, message: Dict[str, Any], user_id: str):
         """Broadcast message to all connections of a specific user."""
         disconnected = set()
         for websocket in self.active_connections[user_id]:
@@ -301,7 +301,7 @@ class WebSocketConnectionManager:
             )
             await self.disconnect(websocket)
 
-    def get_connection_stats(self) -> dict[str, Any]:
+    def get_connection_stats(self) -> Dict[str, Any]:
         """Get connection statistics."""
         total_connections = sum(
             len(connections) for connections in self.active_connections.values()
@@ -346,7 +346,7 @@ class UserProfile(BaseModel):
     username: str = Field(..., description="Username")
     email: str = Field(..., description="Email address")
     full_name: str = Field(..., description="Full name")
-    permissions: list[str] = Field(
+    permissions: List[str] = Field(
         default_factory=list, description="User permissions"
     )
     created_at: str = Field(..., description="Account creation date")
@@ -529,7 +529,7 @@ async def metrics() -> Response:
     return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
 
-def _tx_to_dict(result: Any) -> dict[str, Any]:
+def _tx_to_dict(result: Any) -> Dict[str, Any]:
     """Normalize transcription result (dataclass or dict) to a plain dict."""
     if isinstance(result, dict):
         return result
@@ -603,8 +603,8 @@ def _write_temp_wav(content: bytes) -> str:
 
 
 def _normalize_transcription_dict(
-    d: dict[str, Any],
-) -> tuple[str, str, float, float, int, float, str]:
+    d: Dict[str, Any],
+) -> Tuple[str, str, float, float, int, float, str]:
     """Normalize transcription attributes from a dict payload."""
     text_val = d.get("text", "")
     lang_val = d.get("language", "unknown")
@@ -637,7 +637,7 @@ def _infer_quality_from_duration(duration: float) -> str:
 
 def _normalize_transcription_obj(
     obj: Any,
-) -> tuple[str, str, float, float, int, float, str]:
+) -> Tuple[str, str, float, float, int, float, str]:
     """Normalize attributes from an object-like transcription result."""
     text_val = getattr(obj, "text", "")
     lang_val = getattr(obj, "language", "unknown")
@@ -665,7 +665,7 @@ def _normalize_transcription_obj(
 
 def _normalize_transcription_attrs(
     result: Any,
-) -> tuple[str, str, float, float, int, float, str]:
+) -> Tuple[str, str, float, float, int, float, str]:
     """Extract common attributes from a transcription result object or dict."""
     if isinstance(result, dict):
         return _normalize_transcription_dict(result)
@@ -724,7 +724,7 @@ def _get_request_scoped_summarizer(model: str):
     return text_summarizer
 
 
-def _derive_emotion(summary_text: str) -> tuple[str, list[str]]:
+def _derive_emotion(summary_text: str) -> Tuple[str, List[str]]:
     """Infer emotional tone and key emotions from summary text."""
     if not summary_text or not emotion_detector:
         return "neutral", []
@@ -876,7 +876,7 @@ class CompleteJournalAnalysis(BaseModel):
 
 # Unified API Endpoints
 @app.get("/health", tags=["System"])
-async def health_check() -> dict[str, Any]:
+async def health_check() -> Dict[str, Any]:
     """Health check endpoint."""
     return {
         "status": "healthy",
@@ -1128,7 +1128,7 @@ class ChatResponse(BaseModel):
     """Chat response payload."""
     reply: str
     summary: Optional[str] = None
-    meta: dict[str, Any] = Field(default_factory=dict)
+    meta: Dict[str, Any] = Field(default_factory=dict)
 
 
 @app.post(
@@ -1219,7 +1219,7 @@ async def chat_websocket(websocket: WebSocket, token: str = Query(None)) -> None
             model = data.get("model", "t5-small")
             reply = f"You said: {text}"
 
-            response: dict[str, Any] = {"reply": reply}
+            response: Dict[str, Any] = {"reply": reply}
             if summarize_flag and text:
                 try:
                     if text_summarizer is None:
@@ -1650,14 +1650,14 @@ async def transcribe_voice(
 )
 async def batch_transcribe_voice(
     request: Request,
-    audio_files: list[UploadFile] = File(
+    audio_files: List[UploadFile] = File(
         ..., description="Multiple audio files to transcribe"
     ),
     language: Optional[str] = Form(
         None, description="Language code for all files"
     ),
     current_user: TokenPayload = Depends(get_current_user),
-) -> dict[str, Any]:
+) -> Dict[str, Any]:
     """Batch process multiple audio files for transcription."""
     start_time = time.time()
     results = []
@@ -1950,7 +1950,7 @@ async def websocket_realtime_processing(websocket: WebSocket, token: str = Query
 )
 async def get_performance_metrics(
     current_user: TokenPayload = Depends(require_permission("monitoring")),
-) -> dict[str, Any]:
+) -> Dict[str, Any]:
     """Get comprehensive performance metrics."""
     try:
         # Get system metrics
@@ -2011,7 +2011,7 @@ async def get_performance_metrics(
 )
 async def detailed_health_check(
     current_user: TokenPayload = Depends(require_permission("monitoring"))
-) -> dict[str, Any]:
+) -> Dict[str, Any]:
     """Comprehensive health check with detailed diagnostics."""
     health_status = "healthy"
     issues = []
@@ -2094,7 +2094,7 @@ async def detailed_health_check(
     summary="Get models status",
     description="Get detailed status information about all AI models in the pipeline",
 )
-async def get_models_status() -> dict[str, Any]:
+async def get_models_status() -> Dict[str, Any]:
     """Get detailed status of all AI models."""
     return {
         "emotion_detector": {
@@ -2132,7 +2132,7 @@ async def get_models_status() -> dict[str, Any]:
     summary="API information",
     description="Get information about the API endpoints and capabilities",
 )
-async def root() -> dict[str, Any]:
+async def root() -> Dict[str, Any]:
     """Root endpoint with API information."""
     return {
         "message": "SAMO AI Unified API is running",


### PR DESCRIPTION
Update type annotations to Python 3.8 compatible syntax to resolve systematic compatibility debt.

---
<a href="https://cursor.com/background-agent?bcId=bc-311e78a4-fa36-40de-855a-36f59a7078bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-311e78a4-fa36-40de-855a-36f59a7078bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

