### PR TITLE
ci(security): add Safety scan to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,27 @@ jobs:
               && echo '⚠️ FastAPI not installed; skipping health check.' \
               || PYTHONPATH="$CIRCLE_WORKING_DIRECTORY/src" python3 -c "from fastapi.testclient import TestClient; from src.unified_ai_api import app; c=TestClient(app); r=c.get('/health'); assert r.status_code==200, f'Health check failed: {r.status_code}'; print('✅ API health check passed!')"
 
+  safety-scan:
+    executor: python-simple
+    steps:
+      - checkout
+      - run:
+          name: Install safety
+          command: |
+            python3 -m pip install --upgrade pip
+            python3 -m pip install safety==3.2.3
+      - run:
+          name: Run safety scans with constraints (fail on high/critical)
+          command: |
+            set -e
+            EXIT=0
+            for req in dependencies/*.txt; do
+              echo "🔍 Scanning $req"
+              # Safety reads installed env or requirement files; use --full-report for clarity
+              safety check --stdin --full-report --fail-on HIGH < "$req" || EXIT=$?
+            done
+            exit $EXIT
+
   # Basic linting (optional - won't fail build)
   code-quality:
     executor: python-simple
@@ -207,6 +228,9 @@ workflows:
   simple-ci:
     jobs:
       - basic-setup
+      - safety-scan:
+          requires:
+            - basic-setup
       - code-quality:
           requires:
             - basic-setup


### PR DESCRIPTION
## Summary
- Adds a Safety vulnerability scan job to CircleCI that checks all dependencies/*.txt and fails on HIGH/CRITICAL findings.

## Changes
- New job safety-scan:
- Installs safety==3.2.3
- Iterates over dependencies/*.txt
- Runs safety check --stdin --full-report --fail-on HIGH
- Wired into simple-ci after basic-setup

## Why
- Phase 3 goal: dependency security and environment hardening
- Early detection of known vulnerabilities before docker-build/test stages

## Notes
- If legitimate false positives occur, we’ll add a scoped ignore policy in a follow‑up PR.
- Constraints are already used elsewhere; this scan focuses on the requirement specs as-is.

## Summary by Sourcery

Add a Safety vulnerability scan job to CircleCI to detect high and critical issues in dependency requirements before build and test stages

CI:
- Add safety-scan job to CircleCI that installs Safety 3.2.3 and scans dependencies/*.txt failing on HIGH/CRITICAL severities
- Integrate safety-scan into the simple-ci workflow after the basic-setup job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated dependency security scanning to the CI pipeline, blocking builds on high-severity issues to strengthen security.
  * Provides detailed vulnerability reports in CI logs for maintainers, improving visibility into dependency risks and release reliability.
  * No user-facing changes; app functionality and performance remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->