### PR TITLE
Add goemotions-deberta as submodule and update README

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "notebooks/goemotions-deberta"]
+	path = notebooks/goemotions-deberta
+	url = https://github.com/uelkerd/goemotions-deberta.git

--- a/README.md
+++ b/README.md
@@ -118,7 +118,9 @@ curl -X POST https://samo-emotion-api-[...].run.app/predict \
 ```
 SAMO--DL/
 ├── notebooks/
-│   └── training/              # Colab training notebooks & experiments
+│   ├── goemotions-deberta/   # 🧠 MAIN TRAINING REPOSITORY
+│   │   └── notebooks/        # Complete training notebooks & experiments
+│   └── training/             # Additional training resources
 ├── deployment/
 │   ├── cloud-run/            # Production ONNX API server
 │   └── local/                # Development environment
@@ -136,6 +138,19 @@ SAMO--DL/
     └── optimization/         # ONNX optimized models
 ```
 
+## 🧠 Training Repository
+
+**Main Training Files**: All model training, experimentation, and optimization work is conducted in the dedicated [goemotions-deberta](https://github.com/uelkerd/goemotions-deberta) repository, located at `notebooks/goemotions-deberta/`.
+
+This repository contains:
+- **Complete training notebooks** for emotion detection model development
+- **Performance optimization scripts** for model fine-tuning
+- **Comprehensive testing frameworks** for model validation
+- **Scientific loss comparison tools** for model improvement
+- **DeBERTa-v3-large implementation** for multi-label emotion classification
+
+> **Note**: The main training work is isolated in this dedicated repository to maintain clean separation between research/experimentation and production deployment code.
+
 ## 🛠️ Development Workflow
 
 ### Model Training (Google Colab)
@@ -150,6 +165,8 @@ trainer = EmotionTrainer(
 )
 trainer.train()  # Achieved 90.70% F1 score
 ```
+
+**Training Repository**: All training notebooks and experiments are located in [`notebooks/goemotions-deberta/`](https://github.com/uelkerd/goemotions-deberta) - the dedicated repository for model development and optimization.
 
 ### Production Deployment
 ```bash
@@ -253,10 +270,14 @@ python deployment/local/api_server.py
 
 ### Model Training
 ```bash
-# Open training notebook in Google Colab
-# Follow notebooks/training/emotion_detection_training.ipynb
+# Main training repository
+cd notebooks/goemotions-deberta/
+# Open training notebooks in Google Colab
+# Follow notebooks/ directory for complete training experiments
 # Experiment with hyperparameters and architectures
 ```
+
+**Training Resources**: The complete training infrastructure is available in the [`goemotions-deberta`](https://github.com/uelkerd/goemotions-deberta) repository with comprehensive notebooks, optimization scripts, and testing frameworks.
 
 
 ## 📅 Project Roadmap

--- a/deployment/secure_api_server.py
+++ b/deployment/secure_api_server.py
@@ -170,11 +170,12 @@ def secure_endpoint(f):
         except Exception as e:
             # Release rate limit slot on error
             rate_limiter.release_request(client_ip, user_agent)
-            
+
             response_time = time.time() - start_time
             update_metrics(response_time, success=False, error_type='endpoint_error')
-            logger.error(f"Endpoint error: {str(e)}")
-            return jsonify({'error': str(e)}), 500
+            # Log detailed error on server but return generic message to user
+            logger.error(f"Endpoint error: {str(e)}", exc_info=True)
+            return jsonify({'error': 'Internal server error occurred'}), 500
     
     return decorated_function
 


### PR DESCRIPTION
This PR integrates the [goemotions-deberta](https://github.com/uelkerd/goemotions-deberta) repository as a git submodule and updates the README to establish clear navigation to the main training location. This creates a clean separation between research/experimentation code and production deployment infrastructure.

## 🎯 Problem Statement

Previously, the main training repository was referenced but not properly integrated into the SAMO-DL project structure. This created:
- **Unclear navigation** for developers looking for training resources
- **Missing version control** integration between training and production code
- **Fragmented documentation** with scattered references to training work

## ✅ Solution Implemented

### Git Submodule Integration
- **Added submodule**: `notebooks/goemotions-deberta/` pointing to the main training repository
- **Created `.gitmodules`**: Proper git submodule configuration
- **Version tracking**: Submodule points to latest commit on main branch
- **Clean separation**: Training code isolated from production deployment

### Documentation Updates
- **Project Structure**: Updated to highlight main training repository location
- **Training Repository Section**: Added dedicated section explaining contents
- **Development Workflow**: Updated model training instructions
- **Getting Started**: Clear navigation to training resources
